### PR TITLE
Fix indentation

### DIFF
--- a/lua/neo-minimap/init.lua
+++ b/lua/neo-minimap/init.lua
@@ -117,8 +117,9 @@ local function __buffer_query_processor(opts)
 				if opts.disable_indentaion then
 					line_text = line_text:gsub("^%s+", "")
 				end
+				local rep = #tostring(row)
 				table.insert(return_tbl.lines, {
-					text = string.rep(" ", #tostring(row)) .. "\t" .. line_text,
+					text = string.rep(" ", rep == 1 and 2 or rep) .. "\t" .. line_text,
 					lnum = row,
 					lcol = col,
 				})

--- a/lua/neo-minimap/init.lua
+++ b/lua/neo-minimap/init.lua
@@ -141,8 +141,9 @@ local function __buffer_query_processor(opts)
 							if opts.disable_indentaion then
 								line = line:gsub("^%s+", "")
 							end
+							local rep = #tostring(row)
 							table.insert(return_tbl.lines, {
-								text = string.rep(" ", #tostring(row)) .. "\t" .. line,
+								text = string.rep(" ", rep == 1 and 2 or rep) .. "\t" .. line,
 								lnum = row - 1,
 								lcol = 0,
 							})


### PR DESCRIPTION
# Description
If items defined between line 0-9(number  with 1 character) then the first letter gets chopped up.
![before](https://user-images.githubusercontent.com/38243998/200052617-ab8e89c9-6913-4d8b-ab51-f78c1ae7979c.png)

# Type of change
- Fix

# Possible solution
- Use min value of 2 for padding in the left side of text

---

I loved your plugin.
Also this is my first pull request