### PR TITLE
Cursor word was cleared

### DIFF
--- a/lua/neo-minimap/init.lua
+++ b/lua/neo-minimap/init.lua
@@ -127,8 +127,7 @@ local function __buffer_query_processor(opts)
 
 	-- Replace {cursorword} attribute with word at cursor
 	if opts.replace_cursorword_attribute then
-		local cursorword = __get_word_at_cursor()
-		current_query = current_query:gsub("%{cursorword}", cursorword)
+		current_query = current_query:gsub("%{cursorword}", opts.cursorword)
 	end
 
 	local ok, iter_query = pcall(vim.treesitter.query.parse_query, opts.filetype, current_query)
@@ -515,6 +514,7 @@ M.set = function(keymaps, pattern, opts)
 					opts.hotswap = nil
 					opts.query_index = i
 					opts.current_cursor_line_pos = vim.api.nvim_win_get_cursor(0)[1]
+					opts.cursorword = __get_word_at_cursor()
 
 					-- user_defaults handling
 					for key, opts_value in pairs(user_defaults) do


### PR DESCRIPTION
sorry but the cursorword I added was a bit buggy. The cursorword was cleared when toggling or using any other then the first keymap. This patch fixes that